### PR TITLE
Update to support 1.20 - 1.20.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
   Toolbar Sounds
 </h1>
 
-> A lightweight datapack for Minecraft 1.19.2
+> A lightweight datapack for Minecraft 1.20 to 1.20.4

--- a/datapack/data/toolbar_sounds/functions/item_switch.mcfunction
+++ b/datapack/data/toolbar_sounds/functions/item_switch.mcfunction
@@ -5,5 +5,5 @@ execute at @s if predicate toolbar_sounds:item_is_potion run playsound item.bott
 execute at @s if predicate toolbar_sounds:item_is_shield run playsound item.armor.equip_iron player @s ~ ~ ~ 1 0.5
 execute at @s if predicate toolbar_sounds:item_is_sword run playsound item.armor.equip_iron player @s ~ ~ ~ 1 1.3
 execute at @s if predicate toolbar_sounds:item_is_tool run playsound item.armor.equip_generic player @s ~ ~ ~ 1 1
-execute at @s unless predicate toolbar_sounds:item_is_unknown run playsound item.bundle.remove_one player @s ~ ~ ~ 0.8 1.3
+execute at @s if predicate toolbar_sounds:item_is_unknown run playsound item.bundle.remove_one player @s ~ ~ ~ 0.8 1.3
 execute at @s store result score @s toolbarSounds.prevSlot run data get entity @s SelectedItemSlot

--- a/datapack/data/toolbar_sounds/predicates/item_is_sword.json
+++ b/datapack/data/toolbar_sounds/predicates/item_is_sword.json
@@ -1,11 +1,23 @@
 {
-  "condition": "minecraft:entity_properties",
-  "entity": "this",
-  "predicate": {
-    "equipment": {
-      "mainhand": {
-        "tag": "toolbar_sounds:swords"
+  "condition": "minecraft:all_of",
+  "terms": [
+    {
+      "condition": "minecraft:inverted",
+      "term": {
+        "condition": "minecraft:reference",
+        "name": "toolbar_sounds:item_is_blunt"
+      }
+    },
+    {
+      "condition": "minecraft:entity_properties",
+      "entity": "this",
+      "predicate": {
+        "equipment": {
+          "mainhand": {
+            "tag": "toolbar_sounds:swords"
+          }
+        }
       }
     }
-  }
+  ]
 }

--- a/datapack/data/toolbar_sounds/predicates/item_is_unknown.json
+++ b/datapack/data/toolbar_sounds/predicates/item_is_unknown.json
@@ -1,5 +1,5 @@
 {
-  "condition": "minecraft:alternative",
+  "condition": "minecraft:any_of",
   "terms": [
     {
       "condition": "minecraft:reference",

--- a/datapack/data/toolbar_sounds/predicates/item_is_unknown.json
+++ b/datapack/data/toolbar_sounds/predicates/item_is_unknown.json
@@ -1,29 +1,32 @@
 {
-  "condition": "minecraft:any_of",
-  "terms": [
-    {
-      "condition": "minecraft:reference",
-      "name": "toolbar_sounds:item_is_blunt"
-    },
-    {
-      "condition": "minecraft:reference",
-      "name": "toolbar_sounds:item_is_bow"
-    },
-    {
-      "condition": "minecraft:reference",
-      "name": "toolbar_sounds:item_is_potion"
-    },
-    {
-      "condition": "minecraft:reference",
-      "name": "toolbar_sounds:item_is_shield"
-    },
-    {
-      "condition": "minecraft:reference",
-      "name": "toolbar_sounds:item_is_sword"
-    },
-    {
-      "condition": "minecraft:reference",
-      "name": "toolbar_sounds:item_is_tool"
-    }
-  ]
+  "condition": "minecraft:inverted",
+  "term": {
+    "condition": "minecraft:any_of",
+    "terms": [
+      {
+        "condition": "minecraft:reference",
+        "name": "toolbar_sounds:item_is_blunt"
+      },
+      {
+        "condition": "minecraft:reference",
+        "name": "toolbar_sounds:item_is_bow"
+      },
+      {
+        "condition": "minecraft:reference",
+        "name": "toolbar_sounds:item_is_potion"
+      },
+      {
+        "condition": "minecraft:reference",
+        "name": "toolbar_sounds:item_is_shield"
+      },
+      {
+        "condition": "minecraft:reference",
+        "name": "toolbar_sounds:item_is_sword"
+      },
+      {
+        "condition": "minecraft:reference",
+        "name": "toolbar_sounds:item_is_tool"
+      }
+    ]
+  }
 }

--- a/datapack/data/toolbar_sounds/tags/items/swords.json
+++ b/datapack/data/toolbar_sounds/tags/items/swords.json
@@ -1,9 +1,7 @@
 {
   "replace": false,
   "values": [
-    "minecraft:diamond_sword",
-    "minecraft:golden_sword",
-    "minecraft:iron_sword",
-    "minecraft:netherite_sword"
+    "#minecraft:swords",
+    "minecraft:trident"
   ]
 }

--- a/datapack/data/toolbar_sounds/tags/items/tools.json
+++ b/datapack/data/toolbar_sounds/tags/items/tools.json
@@ -1,21 +1,9 @@
 {
   "replace": false,
   "values": [
-    "minecraft:diamond_axe",
-    "minecraft:diamond_hoe",
-    "minecraft:diamond_pickaxe",
-    "minecraft:diamond_shovel",
-    "minecraft:golden_axe",
-    "minecraft:golden_hoe",
-    "minecraft:golden_pickaxe",
-    "minecraft:golden_shovel",
-    "minecraft:iron_axe",
-    "minecraft:iron_hoe",
-    "minecraft:iron_pickaxe",
-    "minecraft:iron_shovel",
-    "minecraft:netherite_axe",
-    "minecraft:netherite_hoe",
-    "minecraft:netherite_pickaxe",
-    "minecraft:netherite_shovel"
+    "#minecraft:axes",
+    "#minecraft:hoes",
+    "#minecraft:pickaxes",
+    "#minecraft:shovels"
   ]
 }

--- a/datapack/pack.mcmeta
+++ b/datapack/pack.mcmeta
@@ -1,9 +1,10 @@
 {
   "pack": {
-    "pack_format": 10,
+    "pack_format": 15,
+    "supported_formats": { "min_inclusive": 15, "max_inclusive": 26 },
     "description": [
       { "text": "Toolbar sounds", "color": "#9A5CC6" },
-      { "text": "\nby villainous-j / v1.0 / 1.19.2","color":"#21497B" }
+      { "text": "\nby villainous-j / v1.1 / 1.20-1.20.4", "color": "#21497B" }
     ]
   }
 }


### PR DESCRIPTION
## Overview

This PR was primarily started to fix an issue with v1.0 in 1.20+. The unknown item sound wasn't triggering.

There's a separate commit for that fix, followed by some commits to update the pack to 1.20 standards.

Tested to support 1.20 to 1.20.4.

Does not work on:
- 1.19.4, because the condition `all_of` is not yet in Minecraft at that version
- 1.20.5, because the format for predicates changed